### PR TITLE
Update Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ An [Ember CLI](http://www.ember-cli.com/) addon for internationalizing Ember.js 
 
 **This addon is under development and is probably not suitable for production use, and so it has not been published to npm yet. Buyer beware.**
 
-**Note:** This addon uses the Streams API, which is only present in Ember.js 1.9.0 and later. In particular, it targets the Stream and HTMLBars APIs that will be available in the forthcoming Ember 1.10.0 release. Earlier releases of Ember are not supported.
+**Note:** This addon uses the Streams API, which is only present in Ember.js 1.9.0 and later. In particular, it targets the Stream and HTMLBars APIs available in Ember 1.10.0 and later. Earlier releases of Ember are not supported.
 
 ## Installation
 
-To install with Ember CLI 0.1.5 or later:
+To install with Ember CLI 0.2.0 or later (when published to npm):
 
 ```
 ember install:addon ember-i18next

--- a/addon/utils/stream.js
+++ b/addon/utils/stream.js
@@ -4,7 +4,7 @@ import Ember from 'ember';
 `Ember.__loader` is private, but these specific modules were not exposed when the initial
 streamification of Ember's view layer happened.
 
-https://github.com/emberjs/ember.js/pull/9693 is pending to expose them (hopefully in 1.10).
+https://github.com/emberjs/ember.js/pull/9693 is pending to expose them (hopefully in 1.12).
 */
 export default Ember.__loader.require('ember-metal/streams/stream')['default'];
 export var read = Ember.__loader.require('ember-metal/streams/utils')['read'];

--- a/app/helpers/t.js
+++ b/app/helpers/t.js
@@ -1,6 +1,24 @@
 import Stream from 'ember-i18next/utils/stream';
 import { subscribe } from 'ember-i18next/utils/stream';
 
+/**
+ * An HTMLBars helper function that exposes the i18next `t()` function. Automatically
+ * refreshes the translated text if the application's selected locale changes.
+ *
+ * Note: This helper must not be passed through Ember.HTMLBars.makeBoundHelper, since
+ * it is already wrapped in a stream (essentially, it already is an HTMLBars bound
+ * helper). If you find that `{{t}}` always displays the text `[object Object]`, make sure
+ * that you don't have something like `Ember.HTMLBars.makeBoundHelper('t', tHelper)`
+ * in your code. For this reason, the helper should be registered manually with
+ * `Ember.HTMLBars._registerHelper`.
+ *
+ * @param {Object[]} params - An array of resolved order parameters. The first
+ *   element should be the translation key to pass to `t()`.
+ * @param {Object} hash - An object containing the hash parameters.
+ *
+ * @return {Stream} a stream that updates its value if the contents of `params`,
+ *   the values in `hash`, or the application locale change.
+ */
 export default function tHelper(params, hash) {
   var path = params.shift();
 

--- a/app/initializers/t.js
+++ b/app/initializers/t.js
@@ -21,6 +21,13 @@ export function initialize(container, application) {
 
   application.set('i18n', window.i18n);
 
+  Ember.debug('=== Ember.Stream ===');
+  Ember.debug(Ember.Stream);
+
+  // Note: We have to do this ourselves for two reasons:
+  // - the helper needs to manipulate the stream itself, so
+  //   Ember.HTMLBars.makeBoundHelper can't be used.
+  // - to avoid having to add a dash to the name
   registerHelper('t', tHelper);
 
   application.deferReadiness();

--- a/app/initializers/t.js
+++ b/app/initializers/t.js
@@ -21,9 +21,6 @@ export function initialize(container, application) {
 
   application.set('i18n', window.i18n);
 
-  Ember.debug('=== Ember.Stream ===');
-  Ember.debug(Ember.Stream);
-
   // Note: We have to do this ourselves for two reasons:
   // - the helper needs to manipulate the stream itself, so
   //   Ember.HTMLBars.makeBoundHelper can't be used.


### PR DESCRIPTION
Update and add documentation to explain some design decisions made and reflect the fact that Ember.js 1.9.0 and Ember.js 1.10.0 have already been released.