### PR TITLE
Make HTMLBars Helper Compatible With Ember 1.11

### DIFF
--- a/app/helpers/t.js
+++ b/app/helpers/t.js
@@ -14,15 +14,19 @@ import { subscribe } from 'ember-i18next/utils/stream';
  *
  * @param {Object[]} params - An array of resolved order parameters. The first
  *   element should be the translation key to pass to `t()`.
- * @param {Object} hash - An object containing the hash parameters.
+ * @param {Object} hash - An object containing the hash parameters, used for translation
+ *   substitutions.
+ * @param {Object} options - Not used.
+ * @param {Object} env - The HTMLBars environment in which the helper is running.
  *
  * @return {Stream} a stream that updates its value if the contents of `params`,
  *   the values in `hash`, or the application locale change.
  */
-export default function tHelper(params, hash) {
+export default function tHelper(params, hash, options, env) {
+  var view = env.data.view;
   var path = params.shift();
 
-  var container = this.container;
+  var container = view.container;
   var t = container.lookup('utils:t');
   var application = container.lookup('application:main');
 

--- a/tests/acceptance/injections-test.js
+++ b/tests/acceptance/injections-test.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import {module, test} from 'qunit';
 import startApp from '../helpers/start-app';
+import safeReset from '../helpers/safe-reset';
 
 var application;
 
@@ -23,7 +24,9 @@ module('Acceptance: Injections', {
     application = startApp();
   },
   afterEach: function() {
-    Ember.run(application, 'reset');
+    // Rebuild the registry before restarting to work around the following:
+    // https://github.com/emberjs/ember.js/issues/10310
+    safeReset(application);
   }
 });
 

--- a/tests/acceptance/translation-test.js
+++ b/tests/acceptance/translation-test.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import {module, test} from 'qunit';
 import startApp from '../helpers/start-app';
+import safeReset from '../helpers/safe-reset';
 
 var application;
 
@@ -13,7 +14,9 @@ module('Acceptance: Translation', {
     application = startApp();
   },
   afterEach: function() {
-    Ember.run(application, 'reset');
+    // Rebuild the registry before restarting to work around the following:
+    // https://github.com/emberjs/ember.js/issues/10310
+    safeReset(application);
   }
 });
 

--- a/tests/helpers/safe-reset.js
+++ b/tests/helpers/safe-reset.js
@@ -1,0 +1,18 @@
+import Ember from 'ember';
+
+/**
+ * Rebuilds the application registry before resetting the application. Works
+ * around the following GitHub issue, which was causing "Cannot re-register:
+ * `utils:t`, as it has already been resolved." messages in the translation
+ * tests:
+ *
+ * https://github.com/emberjs/ember.js/issues/10310
+ */
+export default function safeReset (app) {
+  Ember.run(function () {
+    if (typeof app.buildRegistry === 'function') {
+      app.registry = app.buildRegistry();
+    }
+    app.reset();
+  });
+}


### PR DESCRIPTION
The `this` pointer in HTMLBars helpers is set to `undefined` by Ember 1.11. This PR changes the way the `t` utility is looked up in the container to find the container via the current view, which is compatible with Ember 1.10 and Ember 1.11. This fixes #5.