### PR TITLE
Pre- and post-init functions

### DIFF
--- a/app/services/i18n.js
+++ b/app/services/i18n.js
@@ -68,6 +68,19 @@ var I18nService = Ember.Service.extend({
   },
 
   /**
+   * Removes an action from the set of actions executed before initializing i18next.
+   *
+   * @param {String|Object} key - the key to use to look up the action to remove.
+   *   May not be blank.
+   */
+  unregisterPreInitAction: function (key) {
+    Ember.assert('Action key may not be blank', !Ember.isBlank(key));
+    var preInitActions = this.get('_preInitActions');
+
+    delete preInitActions[key];
+  },
+
+  /**
    * Registers an action to execute after initializing i18next. After initializing
    * the library or setting the language (which reinitializes the library), each of
    * the registered actions will be executed.
@@ -85,6 +98,20 @@ var I18nService = Ember.Service.extend({
     Ember.assert('A post-init action must be a function', typeof fn === 'function');
     this.get('_postInitActions')[name] = fn;
   },
+
+  /**
+   * Removes an action from the set of actions executed after initializing i18next.
+   *
+   * @param {String|Object} key - the key to use to look up the action to remove.
+   *   May not be blank.
+   */
+  unregisterPostInitAction: function (key) {
+    Ember.assert('Action key may not be blank', !Ember.isBlank(key));
+    var postInitActions = this.get('_postInitActions');
+
+    delete postInitActions[key];
+  },
+
 
   /**
    * Notifies the locale stream when the locale is updated, triggering localized

--- a/tests/acceptance/service-init-actions-test.js
+++ b/tests/acceptance/service-init-actions-test.js
@@ -1,0 +1,40 @@
+import Ember from 'ember';
+import {
+  module,
+  test
+} from 'qunit';
+import startApp from '../helpers/start-app';
+
+var application, container, service;
+
+module('Acceptance: ServiceInitActions', {
+  beforeEach: function() {
+    application = startApp();
+    container = application.__container__;
+    service = container.lookup('service:i18n');
+  },
+
+  afterEach: function() {
+    Ember.run(application, 'destroy');
+  }
+});
+
+test('pre-init actions', function (assert) {
+  assert.expect(1);
+
+  service.registerPreInitAction('test-pre-init', function () {
+    assert.ok(true, 'Service calls pre-init actions on initLibraryAsync');
+  });
+
+  visit('/test-init');
+});
+
+test('post-init actions', function (assert) {
+  assert.expect(1);
+
+  service.registerPostInitAction('test-pre-init', function () {
+    assert.ok(true, 'Service calls post-init actions on initLibraryAsync');
+  });
+
+  visit('/test-init');
+});

--- a/tests/acceptance/service-init-actions-test.js
+++ b/tests/acceptance/service-init-actions-test.js
@@ -32,9 +32,43 @@ test('pre-init actions', function (assert) {
 test('post-init actions', function (assert) {
   assert.expect(1);
 
-  service.registerPostInitAction('test-pre-init', function () {
+  service.registerPostInitAction('test-post-init', function () {
     assert.ok(true, 'Service calls post-init actions on initLibraryAsync');
   });
+
+  visit('/test-init');
+});
+
+test('unregistering pre-int actions', function (assert) {
+  assert.expect(1);
+
+  service.registerPreInitAction('removed-pre-init', function () {
+    // should never get here
+    assert.ok(false, 'Service should not call unregistered actions on init.');
+  });
+
+  service.registerPreInitAction('test-pre-init', function () {
+    assert.ok(true, 'Service should call registered pre-init actions on init.');
+  });
+
+  service.unregisterPreInitAction('removed-pre-init');
+
+  visit('/test-init');
+});
+
+test('unregistering post-int actions', function (assert) {
+  assert.expect(1);
+
+  service.registerPostInitAction('removed-post-init', function () {
+    // should never get here
+    assert.ok(false, 'Service should not call unregistered actions on init.');
+  });
+
+  service.registerPostInitAction('test-post-init', function () {
+    assert.ok(true, 'Service should call registered post-init actions on init.');
+  });
+
+  service.unregisterPostInitAction('removed-post-init');
 
   visit('/test-init');
 });

--- a/tests/acceptance/service-locale-change-actions-test.js
+++ b/tests/acceptance/service-locale-change-actions-test.js
@@ -46,3 +46,45 @@ test('setting language triggers post-init actions', function (assert) {
 
   click('a#change-language-link');
 });
+
+test('unregistering pre-init actions', function (assert) {
+  assert.expect(1);
+
+  visit('/');
+
+  andThen(function() {
+    service.registerPreInitAction('removed-pre-init', function () {
+      // should not get here
+      assert.ok(false, 'Setting locale should not trigger unregistered actions');
+    });
+
+    service.registerPreInitAction('test-pre-init', function () {
+      assert.ok(true, 'Setting locale should triggered pre-init actions');
+    });
+
+    service.unregisterPreInitAction('removed-pre-init');
+  });
+
+  click('a#change-language-link');
+});
+
+test('unregistering post-init actions', function (assert) {
+  assert.expect(1);
+
+  visit('/');
+
+  andThen(function () {
+    service.registerPostInitAction('removed-post-init', function () {
+      // should not get here
+      assert.ok(false, 'Setting locale should not trigger unregistered actions');
+    });
+
+    service.registerPostInitAction('test-post-init', function () {
+      assert.ok(true, 'Setting locale should trigger post-init actions.');
+    });
+
+    service.unregisterPostInitAction('removed-post-init');
+  });
+
+  click('a#change-language-link');
+});

--- a/tests/acceptance/service-locale-change-actions-test.js
+++ b/tests/acceptance/service-locale-change-actions-test.js
@@ -1,0 +1,48 @@
+import Ember from 'ember';
+import {
+  module,
+  test
+} from 'qunit';
+import startApp from '../helpers/start-app';
+
+var application, container, service;
+
+module('Acceptance: ServiceLocaleChangeActions', {
+  beforeEach: function() {
+    application = startApp();
+    container = application.__container__;
+    service = container.lookup('service:i18n');
+  },
+
+  afterEach: function() {
+    Ember.run(application, 'destroy');
+  }
+});
+
+test('setting language triggers pre-init actions', function (assert) {
+  assert.expect(1);
+
+  visit('/');
+
+  andThen(function() {
+    service.registerPreInitAction('test-pre-init', function () {
+      assert.ok(true, 'Setting locale triggers pre-init action');
+    });
+  });
+
+  click('a#change-language-link');
+});
+
+test('setting language triggers post-init actions', function (assert) {
+  assert.expect(1);
+
+  visit('/');
+
+  andThen(function () {
+    service.registerPostInitAction('test-post-init', function () {
+      assert.ok(true, 'Setting locale triggers post-init action');
+    });
+  });
+
+  click('a#change-language-link');
+});

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -6,6 +6,7 @@ var Router = Ember.Router.extend({
 });
 
 Router.map(function() {
+  this.route('test-init');
 });
 
 export default Router;

--- a/tests/dummy/app/routes/test-init.js
+++ b/tests/dummy/app/routes/test-init.js
@@ -1,0 +1,9 @@
+import Ember from 'ember';
+import I18nMixin from '../mixins/i18n';
+
+export default Ember.Route.extend(I18nMixin, {
+  beforeModel: function () {
+    var i18next = this.get('i18n');
+    return i18next.initLibraryAsync();
+  }
+});

--- a/tests/unit/services/i18n-test.js
+++ b/tests/unit/services/i18n-test.js
@@ -17,9 +17,13 @@ test('throws when action names are blank', function (assert) {
   var service = this.subject();
 
   assert.throws(function () { service.registerPreInitAction('', function () {}); },
-    'Throws if pre-init action name is blank.');
+    'Throws if registered pre-init action name is blank.');
   assert.throws(function () { service.registerPostInitAction('', function () {}); },
-    'Throws if post-init action name is blank.');
+    'Throws if registered post-init action name is blank.');
+  assert.throws(function() { service.unregisterPreInitAction(''); },
+    'Throws if unregistered pre-init action name is blank.');
+  assert.throws(function () { service.unregisterPostInitAction(''); },
+    'Throws if unregistered post-init action name is blank.');
 });
 
 test('throws when actions are not functions', function (assert) {

--- a/tests/unit/services/i18n-test.js
+++ b/tests/unit/services/i18n-test.js
@@ -1,4 +1,3 @@
-import Ember from 'ember';
 import {
   moduleFor,
   test

--- a/tests/unit/services/i18n-test.js
+++ b/tests/unit/services/i18n-test.js
@@ -1,3 +1,4 @@
+import Ember from 'ember';
 import {
   moduleFor,
   test
@@ -8,8 +9,25 @@ moduleFor('service:i18n', {
   // needs: ['service:foo']
 });
 
-// Replace this with your real tests.
 test('it exists', function(assert) {
   var service = this.subject();
   assert.ok(service);
+});
+
+test('throws when action names are blank', function (assert) {
+  var service = this.subject();
+
+  assert.throws(function () { service.registerPreInitAction('', function () {}); },
+    'Throws if pre-init action name is blank.');
+  assert.throws(function () { service.registerPostInitAction('', function () {}); },
+    'Throws if post-init action name is blank.');
+});
+
+test('throws when actions are not functions', function (assert) {
+  var service = this.subject();
+
+  assert.throws(function () { service.registerPreInitAction('woo', 'woo'); },
+   'Throws if pre-init action is not a function.');
+  assert.throws(function () { service.registerPostInitAction('woo', 'hoo'); },
+    'Throws if post-init action is not a function.');
 });


### PR DESCRIPTION
Allow registration of actions to execute before i18next functions that destroy library state are called. Makes it possible to cache and restore or re-fetch resources when the library is initialized or the locale changes.