### PR TITLE
Init promise refactor

### DIFF
--- a/tests/acceptance/mixin-test.js
+++ b/tests/acceptance/mixin-test.js
@@ -15,7 +15,7 @@ function testTranslation (assert, subject, key, options, expected) {
 }
 
 function testTranslations (assert, subject) {
-  testTranslation(assert, subject, 'test', {}, 'test output');
+  testTranslation(assert, subject, 'test', { lng: 'en' }, 'test output');
   testTranslation(assert, subject, 'test', { lng: 'th' }, 'thai test output');
 }
 

--- a/tests/acceptance/service-locale-change-actions-test.js
+++ b/tests/acceptance/service-locale-change-actions-test.js
@@ -23,6 +23,7 @@ test('setting language triggers pre-init actions', function (assert) {
   assert.expect(1);
 
   visit('/');
+  click('a#change-language-en');
 
   andThen(function() {
     service.registerPreInitAction('test-pre-init', function () {
@@ -30,13 +31,14 @@ test('setting language triggers pre-init actions', function (assert) {
     });
   });
 
-  click('a#change-language-link');
+  click('a#change-language-th');
 });
 
 test('setting language triggers post-init actions', function (assert) {
   assert.expect(1);
 
   visit('/');
+  click('a#change-language-en');
 
   andThen(function () {
     service.registerPostInitAction('test-post-init', function () {
@@ -44,13 +46,14 @@ test('setting language triggers post-init actions', function (assert) {
     });
   });
 
-  click('a#change-language-link');
+  click('a#change-language-th');
 });
 
 test('unregistering pre-init actions', function (assert) {
   assert.expect(1);
 
   visit('/');
+  click('a#change-language-en');
 
   andThen(function() {
     service.registerPreInitAction('removed-pre-init', function () {
@@ -65,13 +68,14 @@ test('unregistering pre-init actions', function (assert) {
     service.unregisterPreInitAction('removed-pre-init');
   });
 
-  click('a#change-language-link');
+  click('a#change-language-th');
 });
 
 test('unregistering post-init actions', function (assert) {
   assert.expect(1);
 
   visit('/');
+  click('a#change-language-en');
 
   andThen(function () {
     service.registerPostInitAction('removed-post-init', function () {
@@ -86,5 +90,5 @@ test('unregistering post-init actions', function (assert) {
     service.unregisterPostInitAction('removed-post-init');
   });
 
-  click('a#change-language-link');
+  click('a#change-language-th');
 });

--- a/tests/acceptance/translation-test.js
+++ b/tests/acceptance/translation-test.js
@@ -22,6 +22,8 @@ module('Acceptance: Translation', {
 
 test('English translations are correct', function(assert) {
   visit('/');
+  click('a#change-language-en');
+  click('a#change-count-1000');
 
   andThen(function() {
     assert.equal(find('div#translated').text(), 'test output');
@@ -34,7 +36,8 @@ test('English translations are correct', function(assert) {
 
 test('Changing locale changes text', function(assert) {
   visit('/');
-  click('a#change-language-link');
+  click('a#change-language-th');
+  click('a#change-count-1000');
 
   andThen(function () {
     assert.equal(find('div#translated').text(), 'thai test output');
@@ -47,12 +50,14 @@ test('Changing locale changes text', function(assert) {
 
 test('Changing bound params changes text', function(assert) {
   visit('/');
+  click('a#change-language-en');
+  click('a#change-count-1000');
 
   andThen(function () {
     assert.equal(find('div#translated-with-bound-args').text(), '1000 frogs');
   });
 
-  click('a#change-count-link');
+  click('a#change-count-5000');
 
   andThen(function () {
     assert.equal(find('div#translated-with-bound-args').text(), '5000 frogs');

--- a/tests/dummy/app/routes/index.js
+++ b/tests/dummy/app/routes/index.js
@@ -14,13 +14,13 @@ export default Ember.Route.extend(I18nMixin, {
   },
 
   actions: {
-    changeLanguage: function () {
+    changeLanguage: function (lang) {
       var service = this.get('i18n');
-      service.set('locale', 'th');
+      service.set('locale', lang);
     },
 
-    changeCount: function () {
-      this.get('countObj').set('count', 5000);
+    changeCount: function (count) {
+      this.get('countObj').set('count', count);
     }
   }
 });

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -3,5 +3,7 @@
 <div id="translated-with-args1">{{t "testarg" count=1}}</div>
 <div id="translated-with-args3">{{t "testarg" count=3}}</div>
 <div id="translated-with-bound-args">{{t "testarg" count=model.count}}</div>
-<div><a id="change-language-link" href="#" {{action 'changeLanguage'}}>Change Language</a></div>
-<div><a id="change-count-link" href="#" {{action 'changeCount'}}>Change Count</a></div>
+<div><a id="change-language-en" href="#" {{action 'changeLanguage' 'en'}}>Use English</a></div>
+<div><a id="change-language-th" href="#" {{action 'changeLanguage''th'}}>Use Thai</a></div>
+<div><a id="change-count-1000" href="#" {{action 'changeCount' 1000}}>Set Count = 1000</a></div>
+<div><a id="change-count-5000" href="#" {{action 'changeCount' 5000}}>Set Count = 5000</a></div>

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -18,7 +18,7 @@ module.exports = function(environment) {
         namespaces: [ 'main' ],
         defaultNs: 'main'
       },
-      cookieName: 'locale',
+      useCookie: false,
       preload: [ 'en' ],
       lng: 'en',
       fallbackLng: 'en',


### PR DESCRIPTION
Refactor promises handled during initialization and setting the locale to use an explicit chain of promises rather than `Ember.RSVP.all` to prevent a race condition that occurred with setting the locale.

The refactor above highlighted some issues with the way state is set up in the acceptance tests. The tests were previously implicitly expecting the application to be in a certain state and would fail if they ran in some orders. With this patch, the tests now ensure the application is in the stat they expect before making any assertions.